### PR TITLE
queryAllかqueryかのオプションを設定できるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ WIP
 
 WIP
 
+* **including_invisible_record**: if true, including deleted or archived records (boolean, default: false)
+
 ## Example
 
 ```yaml
@@ -28,6 +30,7 @@ in:
   instance_url: https://sample.force.com
   api_version: 41.0
   soql: SELECT Id, Name, LastModifiedDate FROM Account WHERE LastModifiedDate > :last_date ORDER BY Id
+  including_invisible_record: true
   conditions:
     - {key: last_date, value: '2019-08-19T00:41:38Z' }
   columns:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ WIP
 
 WIP
 
-* **including_invisible_record**: if true, including deleted or archived records (boolean, default: false)
+* **include_deleted_or_archived_records**: if true, include deleted or archived records (boolean, default: false)
 
 ## Example
 
@@ -30,7 +30,7 @@ in:
   instance_url: https://sample.force.com
   api_version: 41.0
   soql: SELECT Id, Name, LastModifiedDate FROM Account WHERE LastModifiedDate > :last_date ORDER BY Id
-  including_invisible_record: true
+  include_deleted_or_archived_records: true
   conditions:
     - {key: last_date, value: '2019-08-19T00:41:38Z' }
   columns:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.1.0"
+version = "0.1.1"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/soql/ForceClient.java
+++ b/src/main/java/org/embulk/input/soql/ForceClient.java
@@ -65,7 +65,7 @@ public class ForceClient
 
     public List<String> query(PluginTask pluginTask) throws AsyncApiException, InterruptedException, ExecutionException
     {
-        this.jobInfo = createJobInfo(pluginTask.getObject(), pluginTask.getIncludingInvisibleRecord());
+        this.jobInfo = createJobInfo(pluginTask.getObject(), pluginTask.getIncludeDeletedOrArchivedRecords());
         this.batchInfo = createBatchInfo(pluginTask.getSoql(), jobInfo);
 
         CompletableFuture<String[]> result = execBatch(jobInfo, batchInfo);
@@ -118,11 +118,11 @@ public class ForceClient
         return batchExecutor.getBatchInfo().getState() != BatchStateEnum.Completed;
     }
 
-    private JobInfo createJobInfo(String object, boolean includingInvisibleRecord) throws AsyncApiException
+    private JobInfo createJobInfo(String object, boolean includeDeletedOrArchivedRecords) throws AsyncApiException
     {
         JobInfo jobInfo = new JobInfo();
         jobInfo.setObject(object);
-        OperationEnum operation = includingInvisibleRecord ? OperationEnum.queryAll : OperationEnum.query;
+        OperationEnum operation = includeDeletedOrArchivedRecords ? OperationEnum.queryAll : OperationEnum.query;
         jobInfo.setOperation(operation);
         jobInfo.setConcurrencyMode(ConcurrencyMode.Parallel);
         jobInfo.setContentType(ContentType.CSV);

--- a/src/main/java/org/embulk/input/soql/ForceClient.java
+++ b/src/main/java/org/embulk/input/soql/ForceClient.java
@@ -63,12 +63,10 @@ public class ForceClient
         return this.batchInfo;
     }
 
-    public List<String> query(
-        String object,
-        String soql) throws AsyncApiException, InterruptedException, ExecutionException
+    public List<String> query(PluginTask pluginTask) throws AsyncApiException, InterruptedException, ExecutionException
     {
-        this.jobInfo = createJobInfo(object);
-        this.batchInfo = createBatchInfo(soql, jobInfo);
+        this.jobInfo = createJobInfo(pluginTask.getObject(), pluginTask.getIncludingInvisibleRecord());
+        this.batchInfo = createBatchInfo(pluginTask.getSoql(), jobInfo);
 
         CompletableFuture<String[]> result = execBatch(jobInfo, batchInfo);
         return Arrays.asList(result.get());
@@ -120,11 +118,12 @@ public class ForceClient
         return batchExecutor.getBatchInfo().getState() != BatchStateEnum.Completed;
     }
 
-    private JobInfo createJobInfo(String object) throws AsyncApiException
+    private JobInfo createJobInfo(String object, boolean includingInvisibleRecord) throws AsyncApiException
     {
         JobInfo jobInfo = new JobInfo();
         jobInfo.setObject(object);
-        jobInfo.setOperation(OperationEnum.query);
+        OperationEnum operation = includingInvisibleRecord ? OperationEnum.queryAll : OperationEnum.query;
+        jobInfo.setOperation(operation);
         jobInfo.setConcurrencyMode(ConcurrencyMode.Parallel);
         jobInfo.setContentType(ContentType.CSV);
         jobInfo = bulkConnection.createJob(jobInfo);

--- a/src/main/java/org/embulk/input/soql/PluginTask.java
+++ b/src/main/java/org/embulk/input/soql/PluginTask.java
@@ -29,9 +29,9 @@ interface PluginTask extends Task
     @Config("object")
     String getObject();
 
-    @Config("including_invisible_record")
+    @Config("include_deleted_or_archived_records")
     @ConfigDefault("false")
-    boolean getIncludingInvisibleRecord();
+    boolean getIncludeDeletedOrArchivedRecords();
 
     @Config("soql")
     String getSoql();

--- a/src/main/java/org/embulk/input/soql/PluginTask.java
+++ b/src/main/java/org/embulk/input/soql/PluginTask.java
@@ -29,6 +29,10 @@ interface PluginTask extends Task
     @Config("object")
     String getObject();
 
+    @Config("including_invisible_record")
+    @ConfigDefault("false")
+    boolean getIncludingInvisibleRecord();
+
     @Config("soql")
     String getSoql();
 

--- a/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
+++ b/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
@@ -48,7 +48,7 @@ public class SoqlFilePlugin implements FileInputPlugin
         PluginTask pluginTask = taskSource.loadTask(PluginTask.class);
         try {
             ForceClient forceClient = new ForceClient(pluginTask);
-            List<String> recordKeyList = forceClient.query(pluginTask.getObject(), pluginTask.getSoql());
+            List<String> recordKeyList = forceClient.query(pluginTask);
             BulkConnection bulkConnection = forceClient.getBulkConnection();
             JobInfo jobInfo = forceClient.getJobInfo();
             BatchInfo batchInfo = forceClient.getBatchInfo();


### PR DESCRIPTION
現状レコードの取得に`query()`
https://developer.salesforce.com/docs/atlas.ja-jp.api.meta/api/sforce_api_calls_query.htm
を使用しているが、それだとアーカイブ済み、削除済みのレコードは取得できない。

アーカイブ済み、削除済みのレコードも取得できるようにオプションを追加した。