### PR TITLE
bump up 0.1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ configurations {
     provided
 }
 
-version = "0.1.1"
+version = "0.1.2"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8


### PR DESCRIPTION
0.1.1はすでにpushされているので0.1.2だった。

>Pushing gem to https://rubygems.pkg.github.com/trocco-io...
Error: Version 0.1.1 of "embulk-input-soql_file" has already been pushed.
Error: Process completed with exit code 1.

https://github.com/trocco-io/embulk-input-soql_file/actions/runs/1990468845