### PR TITLE
oauth対応

### DIFF
--- a/src/main/java/org/embulk/input/soql/AuthMethod.java
+++ b/src/main/java/org/embulk/input/soql/AuthMethod.java
@@ -1,0 +1,14 @@
+package org.embulk.input.soql;
+
+public enum AuthMethod
+{
+    oauth("oauth"),
+    user_password("user_password");
+
+    private final String string;
+
+    AuthMethod(final String string)
+    {
+        this.string = string;
+    }
+}

--- a/src/main/java/org/embulk/input/soql/ConnectorConfigCreater.java
+++ b/src/main/java/org/embulk/input/soql/ConnectorConfigCreater.java
@@ -1,0 +1,8 @@
+package org.embulk.input.soql;
+
+import com.sforce.ws.ConnectionException;
+import com.sforce.ws.ConnectorConfig;
+
+interface ConnectorConfigCreater {
+    ConnectorConfig createConnectorConfig() throws ConnectionException;
+}

--- a/src/main/java/org/embulk/input/soql/OauthConnectorConfigCreater.java
+++ b/src/main/java/org/embulk/input/soql/OauthConnectorConfigCreater.java
@@ -1,0 +1,22 @@
+package org.embulk.input.soql;
+
+import com.sforce.ws.ConnectorConfig;
+
+class OauthConnectorConfigCreater implements ConnectorConfigCreater {
+    final PluginTask pluginTask;
+
+    OauthConnectorConfigCreater(final PluginTask pluginTask) {
+        this.pluginTask = pluginTask;
+    }
+
+    public ConnectorConfig createConnectorConfig() {
+        ConnectorConfig config = new ConnectorConfig();
+        config.setSessionId(pluginTask.getAccessToken().get());
+        String restEndpoint = pluginTask.getInstanceUrl().get() + "/services/async/" + pluginTask.getApiVersion();
+
+        config.setRestEndpoint(restEndpoint);
+        config.setCompression(true);
+        config.setTraceMessage(false);
+        return config;
+    }
+}

--- a/src/main/java/org/embulk/input/soql/PluginTask.java
+++ b/src/main/java/org/embulk/input/soql/PluginTask.java
@@ -7,24 +7,41 @@ import org.embulk.config.Task;
 import org.embulk.spi.BufferAllocator;
 import org.embulk.spi.SchemaConfig;
 
+import java.util.Optional;
+
 interface PluginTask extends Task
 {
+    @Config("auth_method")
+    @ConfigDefault("\"user_password\"")
+    AuthMethod getAuthMethod();
+
+    @Config("instance_url")
+    @ConfigDefault("null")
+    Optional<String> getInstanceUrl();
+
+    @Config("access_token")
+    @ConfigDefault("null")
+    Optional<String> getAccessToken();
+
     @Config("username")
-    String getUsername();
+    @ConfigDefault("null")
+    Optional<String> getUsername();
 
     @Config("password")
-    String getPassword();
+    @ConfigDefault("null")
+    Optional<String> getPassword();
 
     @Config("api_version")
     @ConfigDefault("\"46.0\"")
     String getApiVersion();
 
     @Config("security_token")
-    String getSecurityToken();
+    @ConfigDefault("null")
+    Optional<String> getSecurityToken();
 
     @Config("auth_end_point")
     @ConfigDefault("\"https://login.salesforce.com/services/Soap/u/\"")
-    String getAuthEndPoint();
+    Optional<String> getAuthEndPoint();
 
     @Config("object")
     String getObject();

--- a/src/main/java/org/embulk/input/soql/UserPasswordConnectorConfigCreater.java
+++ b/src/main/java/org/embulk/input/soql/UserPasswordConnectorConfigCreater.java
@@ -1,0 +1,31 @@
+package org.embulk.input.soql;
+
+import com.sforce.soap.partner.PartnerConnection;
+import com.sforce.ws.ConnectionException;
+import com.sforce.ws.ConnectorConfig;
+
+class UserPasswordConnectorConfigCreater implements ConnectorConfigCreater {
+    final PluginTask pluginTask;
+
+    UserPasswordConnectorConfigCreater(final PluginTask pluginTask) {
+        this.pluginTask = pluginTask;
+    }
+
+    public ConnectorConfig createConnectorConfig() throws ConnectionException {
+        ConnectorConfig partnerConfig = new ConnectorConfig();
+        partnerConfig.setUsername(pluginTask.getUsername().get());
+        partnerConfig.setPassword(pluginTask.getPassword().get() + pluginTask.getSecurityToken().get());
+        partnerConfig.setAuthEndpoint(pluginTask.getAuthEndPoint().get() + pluginTask.getApiVersion());
+        new PartnerConnection(partnerConfig);
+
+        ConnectorConfig config = new ConnectorConfig();
+        config.setSessionId(partnerConfig.getSessionId());
+        String soapEndpoint = partnerConfig.getServiceEndpoint();
+        String restEndpoint = soapEndpoint.substring(0, soapEndpoint.indexOf("Soap/")) + "async/" + pluginTask.getApiVersion();
+        config.setRestEndpoint(restEndpoint);
+        config.setCompression(true);
+        config.setTraceMessage(false);
+
+        return config;
+    }
+}


### PR DESCRIPTION
アクセストークンでリクエストするには、メタデータAPIについての記述だが
>この例では、ユーザとパスワードの認証を使用してセッション ID が取得され、セッション ID が Metadata API へのコールを行うために使用されます。または、OAuth 認証を使用することもできます。OAuth で Salesforce に認証した後、返されたアクセストークンをセッション ID の代わりに渡します。たとえば、アクセストークンを ConnectorConfig の setSessionId() コールに渡します。Salesforce で OAuth 認証を使用する方法についての詳細は、Salesforce ヘルプの[「OAuth によるアプリケーションの認証」](https://help.salesforce.com/apex/HTViewHelpDoc?id=remoteaccess_authenticate.htm&language=ja)を参照してください。
https://developer.salesforce.com/docs/atlas.ja-jp.api_meta.meta/api_meta/meta_quickstart_java_sample.htm

BulkAPIでもsetSessionId()にアクセストークンを渡せばいけると考え、実際に試したところ動作したのでこの方法で実装した。
(他にアクセストークンを利用したリクエストの仕方を調べたが見つからなかった)


プラグインに渡すconfigとして、新たに3つ追加。
- auth_method
  - username, passwordによる認証か、OAuthによるものかを判別するのに使う
  - 既存のデータには含まれてないのでデフォルトではusername, passwordによる認証になるように
- access_token
  - OAuthによるリクエストのときに必要
- instance_url
  - RestEndpointが必要でそれを作るのに必要

