### PR TITLE
[RFC] Add support incremental loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Soql input plugin for Embulk
+# SoqlFile input plugin for Embulk
 
-TODO: Write short description here and embulk-input-soql.gemspec file.
+SoqlFile input plugin for Embulk loads records from Salesforce.
 
 ## Overview
 
@@ -9,15 +9,29 @@ TODO: Write short description here and embulk-input-soql.gemspec file.
 * **Cleanup supported**: no
 * **Guess supported**: yes
 
-WIP
-
 ## Configuration
 
-WIP
-
-* **include_deleted_or_archived_records**: if true, include deleted or archived records (boolean, default: false)
+- **type**: `soql_file` (string, required)
+- **username**: login username (string, required)
+- **password**: login password (string, required)
+- **security_token**: security token (string, required)
+- **instance_url**: instance url (string, required)
+- **api_version**: api version number (string, default: 46.0)
+- **auth_end_point**: url for authentication (string, default: `https://login.salesforce.com/services/Soap/u/`)
+- **object**: object name (string, required)
+- **include_deleted_or_archived_records**: if true, include deleted or archived records (boolean, default: false)
+- If you write SOQL directly,
+  - **soql**: SOQL (string)
+- If **soql** is not set,
+  - **select**: SELECT clauses (string)
+  - **where**: WHERE clauses (string)
+- **incremental**: if true, enables incremental loading. See next section for details (boolean, default: false)
+- **incremental_columns**: column names for incremental loading (array of strings). Columns of integer types, string types, `timestamp` are supported.
+- **last_record**: values of the last record for incremental loading (array of objects)
 
 ## Example
+
+Using SOQL directly:
 
 ```yaml
 in:
@@ -25,21 +39,50 @@ in:
   username: sample@example.com
   password: password
   security_token: ***
-  client_id: ***
-  client_secret: ***
   instance_url: https://sample.force.com
   api_version: 41.0
-  soql: SELECT Id, Name, LastModifiedDate FROM Account WHERE LastModifiedDate > :last_date ORDER BY Id
-  include_deleted_or_archived_records: true
-  conditions:
-    - {key: last_date, value: '2019-08-19T00:41:38Z' }
-  columns:
-    - {name: Id, type: string, index: 0}
-    - {name: Name, type: string, index: 1}
-    - {name: LastModifiedDate, type: timestamp, format: '%Y-%m-%dT%H:%M:%S.%L%z', index: 2}
+  auth_end_point: https://login.salesforce.com/services/Soap/u/
+  object: Account
+  soql: "SELECT Id, Name, LastModifiedDate FROM Account"
 ```
 
+Using select, and where (optional):
+
+```yaml
+in:
+  type: soql_file
+  username: sample@example.com
+  password: password
+  security_token: ***
+  instance_url: https://sample.force.com
+  api_version: 41.0
+  auth_end_point: https://login.salesforce.com/services/Soap/u/
+  object: Account
+  select: "Id, Name, LastModifiedDate"
+  where: "Name != 'John Doe'"
+```
+
+Using incremental loading:
+
+```yaml
+in:
+  type: soql_file
+  username: sample@example.com
+  password: password
+  security_token: ***
+  instance_url: https://sample.force.com
+  api_version: 41.0
+  auth_end_point: https://login.salesforce.com/services/Soap/u/
+  object: Account
+  select: "Id, Name, LastModifiedDate"
+  where: "Name != 'John Doe'"
+  incremental: true
+  incremental_columns:
+  - Id
+```
 
 ## Build
 
-WIP
+```
+$ ./gradlew gem
+```

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     compile "com.force.api:force-wsc:47.0.0"
     compile "com.force.api:force-partner-api:47.0.0"
+    compile "org.apache.commons:commons-csv:1.11.0"
 
     testImplementation "junit:junit:4.+"
     testImplementation "org.embulk:embulk-core:${embulkVersion}"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -9,12 +9,15 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.force.api:force-partner-api:47.0.0
 com.force.api:force-wsc:47.0.0
 commons-beanutils:commons-beanutils:1.9.3
+commons-codec:commons-codec:1.16.1
 commons-collections:commons-collections:3.2.2
+commons-io:commons-io:2.16.1
 commons-logging:commons-logging:1.2
 javax.validation:validation-api:1.1.0.Final
 org.antlr:ST4:4.0.7
 org.antlr:antlr-runtime:3.5
 org.antlr:stringtemplate:3.2.1
+org.apache.commons:commons-csv:1.11.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.embulk:embulk-api:0.10.36

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -9,12 +9,15 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.force.api:force-partner-api:47.0.0
 com.force.api:force-wsc:47.0.0
 commons-beanutils:commons-beanutils:1.9.3
+commons-codec:commons-codec:1.16.1
 commons-collections:commons-collections:3.2.2
+commons-io:commons-io:2.16.1
 commons-logging:commons-logging:1.2
 javax.validation:validation-api:1.1.0.Final
 org.antlr:ST4:4.0.7
 org.antlr:antlr-runtime:3.5
 org.antlr:stringtemplate:3.2.1
+org.apache.commons:commons-csv:1.11.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.embulk:embulk-util-config:0.3.4

--- a/src/main/java/org/embulk/input/soql/CsvFileInput.java
+++ b/src/main/java/org/embulk/input/soql/CsvFileInput.java
@@ -1,0 +1,41 @@
+package org.embulk.input.soql;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.embulk.config.TaskReport;
+import org.embulk.spi.Exec;
+import org.embulk.spi.TransactionalFileInput;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.embulk.util.file.InputStreamFileInput;
+
+public class CsvFileInput extends InputStreamFileInput implements TransactionalFileInput {
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+            ConfigMapperFactory.builder().addDefaultModules().build();
+
+    private PluginTask task;
+    private List<Path> csvFilePaths;
+
+    public CsvFileInput(PluginTask task, List<Path> csvFilePaths) {
+        super(Exec.getBufferAllocator(), new CsvFileProvider(csvFilePaths));
+        this.task = task;
+        this.csvFilePaths = csvFilePaths;
+    }
+
+    @Override
+    public void abort() {}
+
+    @Override
+    public TaskReport commit() {
+        TaskReport report = CONFIG_MAPPER_FACTORY.newTaskReport();
+
+        // CSV から最大値をとりだす
+        if (task.getIncremental()) {
+            CsvMaxValueFinder finder =
+                    new CsvMaxValueFinder(csvFilePaths, task.getIncrementalColumns());
+            List<String> maxValues = finder.findMaxValues();
+            report.set("last_record", maxValues);
+        }
+
+        return report;
+    }
+}

--- a/src/main/java/org/embulk/input/soql/CsvFileProvider.java
+++ b/src/main/java/org/embulk/input/soql/CsvFileProvider.java
@@ -1,0 +1,30 @@
+package org.embulk.input.soql;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.List;
+import org.embulk.util.file.InputStreamFileInput;
+import org.embulk.util.file.InputStreamFileInput.InputStreamWithHints;
+
+public class CsvFileProvider implements InputStreamFileInput.Provider {
+    private List<Path> csvFilePaths;
+    private Iterator<Path> iterator;
+
+    public CsvFileProvider(List<Path> csvFilePaths) {
+        this.csvFilePaths = csvFilePaths;
+        this.iterator = csvFilePaths.iterator();
+    }
+
+    @Override
+    public InputStreamWithHints openNextWithHints() throws IOException {
+        if (!iterator.hasNext()) {
+            return null;
+        }
+        return new InputStreamWithHints(Files.newInputStream(iterator.next()));
+    }
+
+    @Override
+    public void close() throws IOException {}
+}

--- a/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
+++ b/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
@@ -23,9 +23,11 @@ public class CsvMaxValueFinder {
     @SuppressWarnings("unchecked")
     public List<String> findMaxValues() {
         List<Comparable<?>> maxValues = new ArrayList<>();
+        List<String> maxRawValues = new ArrayList<>();
         List<Boolean> invalidColumns = new ArrayList<>();
         for (int i = 0; i < targetColumnNames.size(); i++) {
             maxValues.add(null);
+            maxRawValues.add(null);
             invalidColumns.add(false);
         }
 
@@ -61,6 +63,7 @@ public class CsvMaxValueFinder {
                                 || (value != null
                                         && ((Comparable) value).compareTo(currentMax) > 0)) {
                             maxValues.set(i, value);
+                            maxRawValues.set(i, valueStr);
                         }
                     }
                 }
@@ -72,19 +75,23 @@ public class CsvMaxValueFinder {
         // 無効な列の結果はnullにする
         for (int i = 0; i < maxValues.size(); i++) {
             if (invalidColumns.get(i)) {
-                maxValues.set(i, null);
+                maxRawValues.set(i, null);
             }
         }
-        // Comparable<?> を String に変換して返却
-        return maxValues.stream()
-                .map(value -> value == null ? null : value.toString())
-                .collect(Collectors.toList());
+        return maxRawValues.stream().collect(Collectors.toList());
     }
 
     private Comparable<?> parseValue(String value) {
         try {
-            // 数値として解釈できる場合
+            // 整数として解釈できる場合
             return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            // 無視して次の解釈へ
+        }
+
+        try {
+            // 小数として解釈できる場合
+            return Double.parseDouble(value);
         } catch (NumberFormatException e) {
             // 無視して次の解釈へ
         }
@@ -96,7 +103,7 @@ public class CsvMaxValueFinder {
             // 無視して次の解釈へ
         }
 
-        // どちらでもなければ文字列として扱う
+        // いずれでもなければ文字列として扱う
         return value;
     }
 }

--- a/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
+++ b/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
@@ -1,8 +1,5 @@
 package org.embulk.input.soql;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -10,6 +7,9 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 
 public class CsvMaxValueFinder {
     private List<Path> csvFilePaths;
@@ -29,46 +29,38 @@ public class CsvMaxValueFinder {
             invalidColumns.add(false);
         }
 
+        CSVFormat csvFormat =
+                CSVFormat.DEFAULT.builder().setHeader().setSkipHeaderRecord(true).build();
         try {
-            for (Path csvPath : csvFilePaths) {
-                try (InputStream inputStream = Files.newInputStream(csvPath);
-                        BufferedReader reader =
-                                new BufferedReader(new InputStreamReader(inputStream))) {
-
-                    String headerLine = reader.readLine(); // 1行目はヘッダ行
-                    if (headerLine == null) {
-                        continue; // ファイルが空なら次のファイルへ
-                    }
-
-                    String[] headers = parseCsvLine(headerLine);
-                    for (String columnName : targetColumnNames) {
-                        if (!isColumnPresent(headers, columnName)) {
-                            System.err.println("Column name not found: " + columnName);
+            for (Path csvFilePath : csvFilePaths) {
+                CSVParser parser = CSVParser.parse(Files.newBufferedReader(csvFilePath), csvFormat);
+                for (CSVRecord record : parser) {
+                    for (int i = 0; i < targetColumnNames.size(); i++) {
+                        // 無効化済みの列は無視する
+                        if (invalidColumns.get(i)) {
                             continue;
                         }
-                    }
 
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        String[] values = parseCsvLine(line);
+                        String columnName = targetColumnNames.get(i);
+                        // 指定された列が存在しない場合は無効化し以降無視する
+                        if (!record.isSet(columnName)) {
+                            invalidColumns.set(i, true);
+                            continue;
+                        }
 
-                        for (int i = 0; i < targetColumnNames.size(); i++) {
-                            String columnName = targetColumnNames.get(i);
-                            int targetColumnIndex = findColumnIndex(headers, columnName);
-                            if (targetColumnIndex >= 0 && values.length > targetColumnIndex) {
-                                Comparable<?> value = parseValue(values[targetColumnIndex].trim());
-                                Comparable<?> currentMax = maxValues.get(i);
-                                // 異なるデータ型が混在する場合はその列を無効化する
-                                if (currentMax != null
-                                        && !currentMax.getClass().equals(value.getClass())) {
-                                    invalidColumns.set(i, true);
-                                } else if (currentMax == null
-                                        || (value != null
-                                                && ((Comparable) value).compareTo(currentMax)
-                                                        > 0)) {
-                                    maxValues.set(i, value);
-                                }
-                            }
+                        String valueStr = record.get(columnName).trim();
+                        Comparable<?> value = parseValue(valueStr);
+                        Comparable<?> currentMax = maxValues.get(i);
+                        // 異なるデータ型が混在する場合はその列を無効化し以降無視する
+                        if (currentMax != null && !currentMax.getClass().equals(value.getClass())) {
+                            invalidColumns.set(i, true);
+                            continue;
+                        }
+                        // 現在の最大値より大きい場合は更新
+                        if (currentMax == null
+                                || (value != null
+                                        && ((Comparable) value).compareTo(currentMax) > 0)) {
+                            maxValues.set(i, value);
                         }
                     }
                 }
@@ -89,24 +81,6 @@ public class CsvMaxValueFinder {
                 .collect(Collectors.toList());
     }
 
-    private boolean isColumnPresent(String[] headers, String columnName) {
-        for (String header : headers) {
-            if (header.trim().equals(columnName)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private int findColumnIndex(String[] headers, String columnName) {
-        for (int i = 0; i < headers.length; i++) {
-            if (headers[i].trim().equals(columnName)) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
     private Comparable<?> parseValue(String value) {
         try {
             // 数値として解釈できる場合
@@ -124,25 +98,5 @@ public class CsvMaxValueFinder {
 
         // どちらでもなければ文字列として扱う
         return value;
-    }
-
-    private String[] parseCsvLine(String line) {
-        List<String> result = new ArrayList<>();
-        StringBuilder current = new StringBuilder();
-        boolean inQuotes = false;
-
-        for (char ch : line.toCharArray()) {
-            if (ch == '"') {
-                inQuotes = !inQuotes; // クオートの開始/終了を反転
-            } else if (ch == ',' && !inQuotes) {
-                result.add(current.toString());
-                current.setLength(0);
-            } else {
-                current.append(ch);
-            }
-        }
-
-        result.add(current.toString()); // 最後のフィールドを追加
-        return result.toArray(new String[0]);
     }
 }

--- a/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
+++ b/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
@@ -1,0 +1,133 @@
+package org.embulk.input.soql;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CsvMaxValueFinder {
+    private List<Path> csvFilePaths;
+    private List<String> targetColumnNames;
+
+    public CsvMaxValueFinder(List<Path> csvFilePaths, List<String> targetColumnNames) {
+        this.csvFilePaths = csvFilePaths;
+        this.targetColumnNames = targetColumnNames;
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> findMaxValues() {
+        List<Comparable<?>> maxValues = new ArrayList<>();
+        for (int i = 0; i < targetColumnNames.size(); i++) {
+            maxValues.add(null);
+        }
+
+        try {
+            for (Path csvPath : csvFilePaths) {
+                try (InputStream inputStream = Files.newInputStream(csvPath);
+                        BufferedReader reader =
+                                new BufferedReader(new InputStreamReader(inputStream))) {
+
+                    String headerLine = reader.readLine(); // 1行目はヘッダ行
+                    if (headerLine == null) {
+                        continue; // ファイルが空なら次のファイルへ
+                    }
+
+                    String[] headers = parseCsvLine(headerLine);
+                    for (String columnName : targetColumnNames) {
+                        if (!isColumnPresent(headers, columnName)) {
+                            System.err.println("Column name not found: " + columnName);
+                            continue;
+                        }
+                    }
+
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        String[] values = parseCsvLine(line);
+
+                        for (int i = 0; i < targetColumnNames.size(); i++) {
+                            String columnName = targetColumnNames.get(i);
+                            int targetColumnIndex = findColumnIndex(headers, columnName);
+                            if (targetColumnIndex >= 0 && values.length > targetColumnIndex) {
+                                Comparable<?> value = parseValue(values[targetColumnIndex].trim());
+                                Comparable<?> currentMax = maxValues.get(i);
+                                if (currentMax == null
+                                        || (value != null
+                                                && ((Comparable) value).compareTo(currentMax)
+                                                        > 0)) {
+                                    maxValues.set(i, value);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            System.err.println("Error processing CSV files: " + e.getMessage());
+        }
+
+        return maxValues.stream().map(Object::toString).collect(Collectors.toList());
+    }
+
+    private boolean isColumnPresent(String[] headers, String columnName) {
+        for (String header : headers) {
+            if (header.trim().equals(columnName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private int findColumnIndex(String[] headers, String columnName) {
+        for (int i = 0; i < headers.length; i++) {
+            if (headers[i].trim().equals(columnName)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private Comparable<?> parseValue(String value) {
+        try {
+            // 数値として解釈できる場合
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            // 無視して次の解釈へ
+        }
+
+        try {
+            // タイムスタンプとして解釈できる場合
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            // 無視して次の解釈へ
+        }
+
+        // どちらでもなければ文字列として扱う
+        return value;
+    }
+
+    private String[] parseCsvLine(String line) {
+        List<String> result = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean inQuotes = false;
+
+        for (char ch : line.toCharArray()) {
+            if (ch == '"') {
+                inQuotes = !inQuotes; // クオートの開始/終了を反転
+            } else if (ch == ',' && !inQuotes) {
+                result.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(ch);
+            }
+        }
+
+        result.add(current.toString()); // 最後のフィールドを追加
+        return result.toArray(new String[0]);
+    }
+}

--- a/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
+++ b/src/main/java/org/embulk/input/soql/CsvMaxValueFinder.java
@@ -23,8 +23,10 @@ public class CsvMaxValueFinder {
     @SuppressWarnings("unchecked")
     public List<String> findMaxValues() {
         List<Comparable<?>> maxValues = new ArrayList<>();
+        List<Boolean> invalidColumns = new ArrayList<>();
         for (int i = 0; i < targetColumnNames.size(); i++) {
             maxValues.add(null);
+            invalidColumns.add(false);
         }
 
         try {
@@ -56,7 +58,11 @@ public class CsvMaxValueFinder {
                             if (targetColumnIndex >= 0 && values.length > targetColumnIndex) {
                                 Comparable<?> value = parseValue(values[targetColumnIndex].trim());
                                 Comparable<?> currentMax = maxValues.get(i);
-                                if (currentMax == null
+                                // 異なるデータ型が混在する場合はその列を無効化する
+                                if (currentMax != null
+                                        && !currentMax.getClass().equals(value.getClass())) {
+                                    invalidColumns.set(i, true);
+                                } else if (currentMax == null
                                         || (value != null
                                                 && ((Comparable) value).compareTo(currentMax)
                                                         > 0)) {
@@ -71,7 +77,16 @@ public class CsvMaxValueFinder {
             System.err.println("Error processing CSV files: " + e.getMessage());
         }
 
-        return maxValues.stream().map(Object::toString).collect(Collectors.toList());
+        // 無効な列の結果はnullにする
+        for (int i = 0; i < maxValues.size(); i++) {
+            if (invalidColumns.get(i)) {
+                maxValues.set(i, null);
+            }
+        }
+        // Comparable<?> を String に変換して返却
+        return maxValues.stream()
+                .map(value -> value == null ? null : value.toString())
+                .collect(Collectors.toList());
     }
 
     private boolean isColumnPresent(String[] headers, String columnName) {

--- a/src/main/java/org/embulk/input/soql/ForceClient.java
+++ b/src/main/java/org/embulk/input/soql/ForceClient.java
@@ -59,12 +59,12 @@ public class ForceClient {
         return this.batchInfo;
     }
 
-    public List<String> query(PluginTask pluginTask)
+    public List<String> query(PluginTask pluginTask, String soql)
             throws AsyncApiException, InterruptedException, ExecutionException {
         this.jobInfo =
                 createJobInfo(
                         pluginTask.getObject(), pluginTask.getIncludeDeletedOrArchivedRecords());
-        this.batchInfo = createBatchInfo(pluginTask.getSoql(), jobInfo);
+        this.batchInfo = createBatchInfo(soql, jobInfo);
 
         CompletableFuture<String[]> result = execBatch(jobInfo, batchInfo);
         return Arrays.asList(result.get());

--- a/src/main/java/org/embulk/input/soql/PluginTask.java
+++ b/src/main/java/org/embulk/input/soql/PluginTask.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;
-import org.embulk.util.config.units.SchemaConfig;
 
 interface PluginTask extends Task {
     @Config("auth_method")
@@ -48,8 +47,4 @@ interface PluginTask extends Task {
 
     @Config("soql")
     String getSoql();
-
-    @Config("columns")
-    @ConfigDefault("[]")
-    SchemaConfig getColumns();
 }

--- a/src/main/java/org/embulk/input/soql/PluginTask.java
+++ b/src/main/java/org/embulk/input/soql/PluginTask.java
@@ -1,5 +1,6 @@
 package org.embulk.input.soql;
 
+import java.util.List;
 import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
@@ -46,5 +47,26 @@ interface PluginTask extends Task {
     boolean getIncludeDeletedOrArchivedRecords();
 
     @Config("soql")
-    String getSoql();
+    @ConfigDefault("null")
+    Optional<String> getSoql();
+
+    @Config("select")
+    @ConfigDefault("null")
+    Optional<String> getSelect();
+
+    @Config("where")
+    @ConfigDefault("null")
+    Optional<String> getWhere();
+
+    @Config("incremental")
+    @ConfigDefault("false")
+    boolean getIncremental();
+
+    @Config("incremental_columns")
+    @ConfigDefault("[]")
+    List<String> getIncrementalColumns();
+
+    @Config("last_record")
+    @ConfigDefault("null")
+    Optional<List<String>> getLastRecord();
 }

--- a/src/main/java/org/embulk/input/soql/SoqlBuilder.java
+++ b/src/main/java/org/embulk/input/soql/SoqlBuilder.java
@@ -1,0 +1,75 @@
+package org.embulk.input.soql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class SoqlBuilder {
+    private String select;
+    private String object;
+    private String where;
+    private List<String> incrementalColumns;
+    private List<String> lastRecords;
+
+    public SoqlBuilder(String select, String object) {
+        this.select = select;
+        this.object = object;
+        this.incrementalColumns = new ArrayList<>();
+    }
+
+    public SoqlBuilder(String select, String object, Optional<String> where) {
+        this(select, object);
+        this.where = where.orElse(null);
+    }
+
+    public SoqlBuilder(
+            String select,
+            String object,
+            Optional<String> where,
+            List<String> incrementalColumns,
+            Optional<List<String>> lastRecords) {
+        this(select, object, where);
+        this.incrementalColumns = Objects.requireNonNull(incrementalColumns);
+        this.lastRecords = lastRecords.orElse(null);
+    }
+
+    public String build() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT " + select);
+        sb.append(" FROM " + object);
+        if (where != null) {
+            sb.append(" WHERE " + where);
+        }
+        // 差分転送のための WHERE 句を生成する:
+        //
+        //   WHERE
+        //     (incremental_columns[0] > last_record[0]
+        //      AND incremental_columns[1] > last_record[1]
+        //      AND ...)
+        if (incrementalColumns.size() > 0 && lastRecords != null && lastRecords.size() > 0) {
+            if (where != null) {
+                sb.append(" AND ");
+            } else {
+                sb.append(" WHERE ");
+            }
+            sb.append("(");
+            for (int i = 0; i < incrementalColumns.size(); i++) {
+                sb.append(incrementalColumns.get(i) + " > " + escape(lastRecords.get(i)));
+                if (i != incrementalColumns.size() - 1) {
+                    sb.append(" AND ");
+                }
+            }
+            sb.append(")");
+        }
+
+        return sb.toString();
+    }
+
+    private String escape(String value) {
+        if (value == null) {
+            return "NULL";
+        }
+        return "'" + value.replace("'", "\\'") + "'";
+    }
+}

--- a/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
+++ b/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
@@ -1,16 +1,26 @@
 package org.embulk.input.soql;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.sforce.async.AsyncApiException;
 import com.sforce.async.BatchInfo;
 import com.sforce.async.BulkConnection;
 import com.sforce.async.JobInfo;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
+import org.embulk.spi.Exec;
 import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.TempFileSpace;
 import org.embulk.spi.TransactionalFileInput;
 import org.embulk.util.config.ConfigMapper;
 import org.embulk.util.config.ConfigMapperFactory;
@@ -20,22 +30,40 @@ import org.slf4j.LoggerFactory;
 
 public class SoqlFilePlugin implements FileInputPlugin {
     private final Logger logger = LoggerFactory.getLogger(SoqlFilePlugin.class);
+
     private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
             ConfigMapperFactory.builder().addDefaultModules().build();
+    private static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+    private static final TaskMapper TASK_MAPPER = CONFIG_MAPPER_FACTORY.createTaskMapper();
+
+    private List<Path> csvFilePaths;
 
     @Override
     public ConfigDiff transaction(ConfigSource config, FileInputPlugin.Control control) {
-        final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
-        final PluginTask pluginTask = configMapper.map(config, PluginTask.class);
+        final PluginTask task = CONFIG_MAPPER.map(config, PluginTask.class);
 
-        return resume(pluginTask.toTaskSource(), 1, control);
+        return buildNextConfigDiff(task, control.run(task.toTaskSource(), 1));
     }
 
     @Override
     public ConfigDiff resume(
             TaskSource taskSource, int taskCount, FileInputPlugin.Control control) {
-        control.run(taskSource, taskCount);
-        return CONFIG_MAPPER_FACTORY.newConfigDiff();
+        final PluginTask task = TASK_MAPPER.map(taskSource, PluginTask.class);
+
+        return buildNextConfigDiff(task, control.run(taskSource, taskCount));
+    }
+
+    public ConfigDiff buildNextConfigDiff(PluginTask task, List<TaskReport> reports) {
+        final ConfigDiff next = CONFIG_MAPPER_FACTORY.newConfigDiff();
+
+        if (reports.size() > 0 && reports.get(0).has("last_record")) {
+            final TaskReport report = CONFIG_MAPPER_FACTORY.rebuildTaskReport(reports.get(0));
+            next.set("last_record", report.get(JsonNode.class, "last_record"));
+        } else if (task.getLastRecord().isPresent()) {
+            next.set("last_record", task.getLastRecord().get());
+        }
+
+        return next;
     }
 
     @Override
@@ -44,8 +72,7 @@ public class SoqlFilePlugin implements FileInputPlugin {
 
     @Override
     public TransactionalFileInput open(TaskSource taskSource, int taskIndex) {
-        final TaskMapper taskMapper = CONFIG_MAPPER_FACTORY.createTaskMapper();
-        final PluginTask pluginTask = taskMapper.map(taskSource, PluginTask.class);
+        final PluginTask pluginTask = TASK_MAPPER.map(taskSource, PluginTask.class);
 
         try {
             ForceClient forceClient = new ForceClient(pluginTask);
@@ -54,15 +81,26 @@ public class SoqlFilePlugin implements FileInputPlugin {
             BulkConnection bulkConnection = forceClient.getBulkConnection();
             JobInfo jobInfo = forceClient.getJobInfo();
             BatchInfo batchInfo = forceClient.getBatchInfo();
-            TransactionalFileInput input =
-                    new SoqlFileInput(
-                            pluginTask,
-                            recordKeyList,
-                            bulkConnection,
-                            jobInfo.getId(),
-                            batchInfo.getId());
+
+            // すべての CSV をダウンロードして Embulk の一時ファイルとして保存する
+            TempFileSpace tempFileSpace = Exec.getTempFileSpace();
+            List<Path> csvFilePaths = new ArrayList<>(recordKeyList.size());
+            try {
+                for (Iterator<String> it = recordKeyList.iterator(); it.hasNext(); ) {
+                    Path csv = tempFileSpace.createTempFile().toPath();
+                    csvFilePaths.add(csv);
+                    InputStream input =
+                            bulkConnection.getQueryResultStream(
+                                    jobInfo.getId(), batchInfo.getId(), it.next());
+                    Files.copy(input, csv, REPLACE_EXISTING);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
             bulkConnection.closeJob(jobInfo.getId());
-            return input;
+
+            return new CsvFileInput(pluginTask, csvFilePaths);
         } catch (AsyncApiException e) {
             logger.error(e.getMessage(), e);
             throw new ConfigException(e);

--- a/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
+++ b/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
@@ -49,7 +49,8 @@ public class SoqlFilePlugin implements FileInputPlugin {
 
         try {
             ForceClient forceClient = new ForceClient(pluginTask);
-            List<String> recordKeyList = forceClient.query(pluginTask);
+            String soql = buildSoql(pluginTask);
+            List<String> recordKeyList = forceClient.query(pluginTask, soql);
             BulkConnection bulkConnection = forceClient.getBulkConnection();
             JobInfo jobInfo = forceClient.getJobInfo();
             BatchInfo batchInfo = forceClient.getBatchInfo();
@@ -69,5 +70,41 @@ public class SoqlFilePlugin implements FileInputPlugin {
             logger.error(e.getMessage(), e);
             throw new RuntimeException(e);
         }
+    }
+
+    private String buildSoql(PluginTask pluginTask) {
+        // 差分転送以外の場合
+        if (pluginTask.getIncremental() == false) {
+            if (pluginTask.getSoql().isPresent()) {
+                return pluginTask.getSoql().get();
+            } else if (pluginTask.getSelect().isPresent()) {
+                SoqlBuilder soqlBuilder =
+                        new SoqlBuilder(
+                                pluginTask.getSelect().get(),
+                                pluginTask.getObject(),
+                                pluginTask.getWhere());
+                return soqlBuilder.build();
+            } else {
+                throw new ConfigException("soql or select must be required");
+            }
+        }
+
+        // 差分転送で SOQL を組み立てれない場合
+        if (!pluginTask.getSelect().isPresent()) {
+            throw new ConfigException("select must be set if incremental is true");
+        }
+        if (pluginTask.getIncrementalColumns().isEmpty()) {
+            throw new ConfigException("incremental_columns must be set if incremental is true");
+        }
+
+        // SOQL を組み立てる
+        SoqlBuilder soqlBuilder =
+                new SoqlBuilder(
+                        pluginTask.getSelect().get(),
+                        pluginTask.getObject(),
+                        pluginTask.getWhere(),
+                        pluginTask.getIncrementalColumns(),
+                        pluginTask.getLastRecord());
+        return soqlBuilder.build();
     }
 }

--- a/src/test/java/org/embulk/input/soql/TestCsvMaxValueFinder.java
+++ b/src/test/java/org/embulk/input/soql/TestCsvMaxValueFinder.java
@@ -1,0 +1,101 @@
+package org.embulk.input.soql;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestCsvMaxValueFinder {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path csvFilePath1;
+    private Path csvFilePath2;
+
+    @Before
+    public void setup() throws IOException {
+        // テスト用のCSVファイルを準備
+        csvFilePath1 =
+                createCsvFile(
+                        "test1.csv",
+                        "id,name,timestamp\n"
+                                + "1,Alice,2024-08-21T10:15:30Z\n"
+                                + "2,Bob,2024-08-22T11:30:00Z\n"
+                                + "3,Charlie,2024-08-20T09:45:00Z\n");
+
+        csvFilePath2 =
+                createCsvFile(
+                        "test2.csv",
+                        "id,name,timestamp\n"
+                                + "4,Dave,2024-08-23T12:00:00Z\n"
+                                + "5,Frank,2024-08-24T13:15:00Z\n"
+                                + "6,Eve,2024-08-19T08:00:00Z\n");
+    }
+
+    @Test
+    public void testFindMaxValuesWithNumber() {
+        CsvMaxValueFinder finder =
+                new CsvMaxValueFinder(
+                        Arrays.asList(csvFilePath1, csvFilePath2), Arrays.asList("id"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        assertEquals(1, maxValues.size());
+        assertEquals("6", maxValues.get(0));
+    }
+
+    @Test
+    public void testFindMaxValuesWithString() {
+        CsvMaxValueFinder finder =
+                new CsvMaxValueFinder(
+                        Arrays.asList(csvFilePath1, csvFilePath2), Arrays.asList("name"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        assertEquals(1, maxValues.size());
+        assertEquals("Frank", maxValues.get(0));
+    }
+
+    @Test
+    public void testFindMaxValuesWithTimestamp() {
+        CsvMaxValueFinder finder =
+                new CsvMaxValueFinder(
+                        Arrays.asList(csvFilePath1, csvFilePath2), Arrays.asList("timestamp"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        assertEquals(1, maxValues.size());
+        assertEquals("2024-08-24T13:15:00Z", maxValues.get(0));
+    }
+
+    @Test
+    public void testFindMaxValuesWithMultipleColumns() {
+        CsvMaxValueFinder finder =
+                new CsvMaxValueFinder(
+                        Arrays.asList(csvFilePath1, csvFilePath2),
+                        Arrays.asList("id", "timestamp"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        assertEquals(2, maxValues.size());
+        assertEquals("6", maxValues.get(0));
+        assertEquals("2024-08-24T13:15:00Z", maxValues.get(1));
+    }
+
+    private Path createCsvFile(String fileName, String content) throws IOException {
+        File csvFile = folder.newFile(fileName);
+        try (BufferedWriter writer = Files.newBufferedWriter(csvFile.toPath())) {
+            writer.write(content);
+        }
+        return csvFile.toPath();
+    }
+}

--- a/src/test/java/org/embulk/input/soql/TestCsvMaxValueFinderException.java
+++ b/src/test/java/org/embulk/input/soql/TestCsvMaxValueFinderException.java
@@ -1,0 +1,96 @@
+package org.embulk.input.soql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestCsvMaxValueFinderException {
+
+    @Rule public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testEmptyCsvFile() throws IOException {
+        Path csv = createCsvFile("empty.csv", "");
+
+        CsvMaxValueFinder finder = new CsvMaxValueFinder(Arrays.asList(csv), Arrays.asList("id"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        assertEquals(1, maxValues.size());
+        assertNull(maxValues.get(0));
+    }
+
+    @Test
+    public void testColumnNotFound() throws IOException {
+        Path csv =
+                createCsvFile(
+                        "test1.csv",
+                        "id,name,timestamp\n"
+                                + "1,Alice,2024-08-21T10:15:30Z\n"
+                                + "2,Bob,2024-08-22T11:30:00Z\n");
+        CsvMaxValueFinder finder =
+                new CsvMaxValueFinder(
+                        Arrays.asList(csv), Arrays.asList("id", "nonexistent_column"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        // カラムが見つからない場合、その列の値はnullとする
+        assertEquals(2, maxValues.size());
+        assertEquals("2", maxValues.get(0));
+        assertNull(maxValues.get(1));
+    }
+
+    @Test
+    public void testInvalidDataFormat() throws IOException {
+        Path csv =
+                createCsvFile(
+                        "invalid_data.csv",
+                        "id,name,timestamp\n"
+                                + "1,Alice,invalid_date_format\n"
+                                + "2,Bob,2024-08-22T11:30:00Z\n");
+
+        CsvMaxValueFinder finder =
+                new CsvMaxValueFinder(Arrays.asList(csv), Arrays.asList("id", "timestamp"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        // 異なるデータ型が混在する場合、その列の値はnullとする
+        assertEquals(2, maxValues.size());
+        assertEquals("2", maxValues.get(0));
+        assertNull(maxValues.get(1));
+    }
+
+    @Test
+    public void testNoHeaderRow() throws IOException {
+        Path csv =
+                createCsvFile(
+                        "no_header.csv",
+                        "1,Alice,2024-08-21T10:15:30Z\n" + "2,Bob,2024-08-22T11:30:00Z\n");
+
+        CsvMaxValueFinder finder = new CsvMaxValueFinder(Arrays.asList(csv), Arrays.asList("id"));
+
+        List<String> maxValues = finder.findMaxValues();
+
+        // ヘッダ行がない場合、結果はnullのリストになる
+        assertEquals(1, maxValues.size());
+        assertNull(maxValues.get(0));
+    }
+
+    private Path createCsvFile(String fileName, String content) throws IOException {
+        File csvFile = folder.newFile(fileName);
+        try (BufferedWriter writer = Files.newBufferedWriter(csvFile.toPath())) {
+            writer.write(content);
+        }
+        return csvFile.toPath();
+    }
+}

--- a/src/test/java/org/embulk/input/soql/TestSoqlBuilder.java
+++ b/src/test/java/org/embulk/input/soql/TestSoqlBuilder.java
@@ -1,0 +1,97 @@
+package org.embulk.input.soql;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Test;
+
+public class TestSoqlBuilder {
+    @Test
+    public void testBuild() {
+        String select = "Id, Name";
+        String object = "Account";
+        SoqlBuilder soqlBuilder = new SoqlBuilder(select, object);
+        String soql = soqlBuilder.build();
+        assertEquals(soql, "SELECT Id, Name FROM Account");
+    }
+
+    @Test
+    public void testBuildWithWhere() {
+        String select = "Id, Name";
+        String object = "Account";
+        Optional<String> where = Optional.of("Name != 'John Doe'");
+        SoqlBuilder soqlBuilder = new SoqlBuilder(select, object, where);
+        String soql = soqlBuilder.build();
+        assertEquals(soql, "SELECT Id, Name FROM Account WHERE Name != 'John Doe'");
+    }
+
+    @Test
+    public void testBuildWithIncrementalColumns() {
+        String select = "Id, Name";
+        String object = "Account";
+        Optional<String> where = Optional.empty();
+        List<String> incrementalColumns = Arrays.asList("Id");
+        Optional<List<String>> lastRecords = Optional.empty();
+        SoqlBuilder soqlBuilder =
+                new SoqlBuilder(select, object, where, incrementalColumns, lastRecords);
+        String soql = soqlBuilder.build();
+        assertEquals(soql, "SELECT Id, Name FROM Account");
+    }
+
+    @Test
+    public void testBuildWithWhereAndIncrementalColumns() {
+        String select = "Id, Name";
+        String object = "Account";
+        Optional<String> where = Optional.of("Name != 'John Doe'");
+        List<String> incrementalColumns = Arrays.asList("Id");
+        Optional<List<String>> lastRecords = Optional.empty();
+        SoqlBuilder soqlBuilder =
+                new SoqlBuilder(select, object, where, incrementalColumns, lastRecords);
+        String soql = soqlBuilder.build();
+        assertEquals(soql, "SELECT Id, Name FROM Account WHERE Name != 'John Doe'");
+    }
+
+    @Test
+    public void testBuildWithIncrementalColumnsAndLastRecords() {
+        String select = "Id, Name";
+        String object = "Account";
+        Optional<String> where = Optional.empty();
+        List<String> incrementalColumns = Arrays.asList("Id");
+        Optional<List<String>> lastRecords = Optional.of(Arrays.asList("1000"));
+        SoqlBuilder soqlBuilder =
+                new SoqlBuilder(select, object, where, incrementalColumns, lastRecords);
+        String soql = soqlBuilder.build();
+        assertEquals(soql, "SELECT Id, Name FROM Account WHERE (Id > '1000')");
+    }
+
+    @Test
+    public void testBuildWithWhereAndIncrementalColumnsAndLastRecords() {
+        String select = "Id, Name";
+        String object = "Account";
+        Optional<String> where = Optional.of("Name != 'John Doe'");
+        List<String> incrementalColumns = Arrays.asList("Id");
+        Optional<List<String>> lastRecords = Optional.of(Arrays.asList("1000"));
+        SoqlBuilder soqlBuilder =
+                new SoqlBuilder(select, object, where, incrementalColumns, lastRecords);
+        String soql = soqlBuilder.build();
+        assertEquals(
+                soql, "SELECT Id, Name FROM Account WHERE Name != 'John Doe' AND (Id > '1000')");
+    }
+
+    @Test
+    public void testBuildWithWhereAndMultipleIncrementalColumnsAndLastRecords() {
+        String select = "Id, Name";
+        String object = "Account";
+        Optional<String> where = Optional.of("Name != 'John Doe'");
+        List<String> incrementalColumns = Arrays.asList("Id", "Name");
+        Optional<List<String>> lastRecords = Optional.of(Arrays.asList("1000", "M"));
+        SoqlBuilder soqlBuilder =
+                new SoqlBuilder(select, object, where, incrementalColumns, lastRecords);
+        String soql = soqlBuilder.build();
+        assertEquals(
+                soql,
+                "SELECT Id, Name FROM Account WHERE Name != 'John Doe' AND (Id > '1000' AND Name > 'M')");
+    }
+}

--- a/src/test/java/org/embulk/input/soql/TestSoqlFilePluginOpen.java
+++ b/src/test/java/org/embulk/input/soql/TestSoqlFilePluginOpen.java
@@ -16,11 +16,8 @@ import org.embulk.util.config.ConfigMapperFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TestSoqlFilePluginOpen {
     private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
             ConfigMapperFactory.builder().addDefaultModules().build();

--- a/src/test/java/org/embulk/input/soql/TestSoqlFilePluginOpen.java
+++ b/src/test/java/org/embulk/input/soql/TestSoqlFilePluginOpen.java
@@ -44,8 +44,9 @@ public class TestSoqlFilePluginOpen {
     public void testOpen() throws Exception {
         final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
         final PluginTask pluginTask = configMapper.map(config(), PluginTask.class);
+        final String soql = pluginTask.getSoql().get();
 
-        when(forceClient.query(pluginTask)).thenReturn(Arrays.asList("record1", "record2"));
+        when(forceClient.query(pluginTask, soql)).thenReturn(Arrays.asList("record1", "record2"));
         when(forceClient.getBulkConnection()).thenReturn(bulkConnection);
         when(forceClient.getJobInfo()).thenReturn(jobInfo);
         when(forceClient.getBatchInfo()).thenReturn(batchInfo);

--- a/src/test/java/org/embulk/input/soql/TestSoqlFilePluginResumeWithSoql.java
+++ b/src/test/java/org/embulk/input/soql/TestSoqlFilePluginResumeWithSoql.java
@@ -1,0 +1,49 @@
+package org.embulk.input.soql;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.util.config.ConfigMapper;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSoqlFilePluginResumeWithSoql {
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+            ConfigMapperFactory.builder().addDefaultModules().build();
+
+    private SoqlFilePlugin plugin;
+
+    @Before
+    public void setup() {
+        plugin = new SoqlFilePlugin();
+    }
+
+    @Test
+    public void testResume() {
+        final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
+        final PluginTask task = configMapper.map(config(), PluginTask.class);
+        final ConfigDiff configDiff = plugin.resume(task.toTaskSource(), 0, new TestControl());
+        assertTrue(configDiff.isEmpty());
+    }
+
+    private ConfigSource config() {
+        return CONFIG_MAPPER_FACTORY
+                .newConfigSource()
+                .set("object", "Account")
+                .set("soql", "SELECT Id,Name FROM Account");
+    }
+
+    private static class TestControl implements FileInputPlugin.Control {
+        @Override
+        public List<TaskReport> run(final TaskSource taskSource, final int taskCount) {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/src/test/java/org/embulk/input/soql/TestSoqlFilePluginTransactionWithIncremental.java
+++ b/src/test/java/org/embulk/input/soql/TestSoqlFilePluginTransactionWithIncremental.java
@@ -1,0 +1,69 @@
+package org.embulk.input.soql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.embulk.config.ConfigDiff;
+import org.embulk.config.ConfigSource;
+import org.embulk.config.TaskReport;
+import org.embulk.config.TaskSource;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.util.config.ConfigMapper;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSoqlFilePluginTransactionWithIncremental {
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+            ConfigMapperFactory.builder().addDefaultModules().build();
+    private static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+
+    private SoqlFilePlugin plugin;
+
+    @Before
+    public void setup() {
+        plugin = new SoqlFilePlugin();
+    }
+
+    @Test
+    public void testTransactionWithLastRecord() {
+        TaskReport report = CONFIG_MAPPER_FACTORY.newTaskReport();
+        List<String> maxValues = new ArrayList<>();
+        maxValues.add("999");
+        report.set("last_record", maxValues);
+
+        List<TaskReport> reports = new ArrayList<>();
+        reports.add(report);
+
+        ConfigDiff configDiff =
+                plugin.transaction(
+                        config(),
+                        new FileInputPlugin.Control() {
+                            @Override
+                            public List<TaskReport> run(
+                                    final TaskSource taskSource, final int taskCount) {
+                                return reports;
+                            }
+                        });
+
+        assertTrue(configDiff.has("last_record"));
+        assertEquals(1, configDiff.get(List.class, "last_record").size());
+        assertEquals("999", configDiff.get(List.class, "last_record").get(0));
+    }
+
+    private ConfigSource config() {
+        return CONFIG_MAPPER_FACTORY
+                .newConfigSource()
+                .set("object", "Account")
+                .set("incremental", true)
+                .set(
+                        "incremental_columns",
+                        new ArrayList<String>() {
+                            {
+                                add("Id");
+                            }
+                        });
+    }
+}

--- a/src/test/java/org/embulk/input/soql/TestSoqlFilePluginTransactionWithSoql.java
+++ b/src/test/java/org/embulk/input/soql/TestSoqlFilePluginTransactionWithSoql.java
@@ -1,46 +1,33 @@
 package org.embulk.input.soql;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
 import org.embulk.spi.FileInputPlugin;
-import org.embulk.util.config.ConfigMapper;
 import org.embulk.util.config.ConfigMapperFactory;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
-public class TestSoqlFilePluginResume {
+public class TestSoqlFilePluginTransactionWithSoql {
     private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
             ConfigMapperFactory.builder().addDefaultModules().build();
-
-    @Rule public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
 
     private SoqlFilePlugin plugin;
 
     @Before
-    public void createResources() {
+    public void setup() {
         plugin = new SoqlFilePlugin();
     }
 
     @Test
     public void testTransaction() {
         final ConfigDiff configDiff = plugin.transaction(config(), new TestControl());
-        assertEquals(configDiff.get(String.class, "object"), "Account");
-    }
-
-    @Test
-    public void testResume() {
-        final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
-        final PluginTask task = configMapper.map(config(), PluginTask.class);
-        final ConfigDiff configDiff = plugin.resume(task.toTaskSource(), 0, new TestControl());
-        assertEquals(configDiff.get(String.class, "object"), "Account");
+        assertTrue(configDiff.isEmpty());
     }
 
     private ConfigSource config() {


### PR DESCRIPTION
差分転送をサポートするための実装です。

# 仕様

JDBC 系の差分転送機能と同様の形になるよう設定の（意味の）変更、追加をしています。

- 変更
    - **object**: 差分転送時にテーブル名として利用。
    - **soql**: SOQL。指定内容で全件取得する。差分転送時には無視される。
- 追加
    - **incremental**: 差分転送の可否（boolean、デフォルトは false）
    - **incremental_columns**: 差分転送の条件として利用するカラム（文字列の配列）
    - **last_record**: 差分転送の条件として指定する値（incremental_columns と同順。文字列の配列）
    - **select**: 差分転送時の SELECT 句（文字列）
    - **where**: 差分転送時の WHERE 句（文字列）

`incremental` が true でかつ `incremental_columns` が空でない場合に差分転送を試みます。また、差分転送では `select`, `where`, `incremental_columns`, `last_record` の値から SOQL を生成しリクエストを行います。

# 実装

このプラグインは FileInputPlugin として実装されているため SoqlFilePlugin#open の返却値として TransactionalFileInput を返却する必要がありますが、TransactionalFileInput を実装するのは SoqlFileInput class で、CSV をダウンロードする部分は SingleFileProvider#openNextWithHints で呼び出されており、返却された HTTP のレスポンスが InputStream になるよう実装されています。

今回の差分転送対応では CSV 内の指定カラムから最大値を取得し次回の転送時に利用できるようにする必要がありますが、そのためにはこのプラグイン内で CSV をパースする処理を追加する必要があります。

これを実現するため今回の実装では以下のようにしてみました。

- SoqlFilePlugin#open で全てのクエリ結果（CSV）を一時ファイルとして保存
- CsvFileInput class で TransactionalFileInput を実装し SoqlFilePlugin#open の返却値としする
- CsvFileInput#commit で CSV から指定カラム最大値の取得し TaskReport として記録
- SoqlFilePlugin#transaction / resume で TaskReport から ConfigDiff を生成する

# 相談

上記を踏まえて、いくつか助言をいただきたいです。

## 1. 並列性について

Salesforce Bulk API (2.0) ではクエリ結果が大きくなった時に複数の CSV に分割されることがあります。その場合既存実装では SingleFileProvider によって InputStream を順次返却しているので、ダウンロードが完了したものから Embulk の次の処理へと制御が移り処理が部分的に並列化できているのではないかと思います。この認識は間違い無いでしょうか？

この認識があっているとすると、今回は最初にすべてをダウンロードしてしまう直列化された実装になっているので、大きなクエリ結果となる場合でのパフォーマンス劣化も考えられますが、Embulk プラグインの作法およびパフォーマンス観点から既存実装と同じような並列性を保つべきでしょうか？

## 2. CSV パースの実装方法について

CSV のパース・最大値取得については CsvMaxValueFinder class にまとめて実装がありますが、一旦 Java の標準ライブラリのみで自前実装しています。入力ソースは Salesforce という点で固定ではあるものの、入力の多様性なサポートやさまざまなエッジケースの対応などを含む目ってメンテナンスの容易性という観点で CSV パース処理の自前実装はなるべく避けたいと考えています。

そのため CSV の処理に関しては何らかのライブラリを使いたいのですが、今回の要件で推奨できるものはありますでしょうか？いまのところ [Apache Commons CSV]( https://commons.apache.org/proper/commons-csv/) が無難そうとは考えています。

# 残タスク

相談レビュー依頼時点では以下がまだ未完了です。追いかけ対応します。

- [x] CSV パース周りの単体テスト
    - 正常系（1カラム、複数カラム、数値、文字列、タイムスタンプ）
    - 異常系（空ファイル、指定カラムなし、ヘッダなし）
- [x] 空ではない ConfigDiff を返却するようになった transaction / resume の単体テスト追加
