### PR TITLE
Strip null bytes from Bulk API CSV responses

### DIFF
--- a/src/main/java/org/embulk/input/soql/NullByteFilterInputStream.java
+++ b/src/main/java/org/embulk/input/soql/NullByteFilterInputStream.java
@@ -1,0 +1,77 @@
+package org.embulk.input.soql;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An InputStream wrapper that filters out null bytes (0x00) from the underlying stream.
+ *
+ * <p>Salesforce Bulk API may return CSV data containing null bytes in text fields, which causes
+ * Embulk's CSV parser to misinterpret them as line terminators, resulting in parse errors.
+ */
+class NullByteFilterInputStream extends FilterInputStream {
+
+    private boolean nullByteDetected = false;
+
+    NullByteFilterInputStream(InputStream in) {
+        super(in);
+    }
+
+    /** Returns true if any null bytes were encountered during reading. */
+    boolean hasDetectedNullBytes() {
+        return nullByteDetected;
+    }
+
+    /** Reads a single byte, skipping over any null bytes (0x00). */
+    @Override
+    public int read() throws IOException {
+        int b;
+        do {
+            b = super.read();
+            if (b == 0) {
+                nullByteDetected = true;
+            }
+        } while (b == 0);
+        return b;
+    }
+
+    /**
+     * Reads into a buffer, filtering out null bytes (0x00) in-place.
+     *
+     * <p>If a chunk consists entirely of null bytes, we must loop and read again rather than
+     * returning 0, since returning 0 from {@code read(byte[], int, int)} signals "no data available
+     * yet" per the InputStream contract, which can cause busy-loops in callers.
+     */
+    @Override
+    public int read(byte[] buf, int off, int len) throws IOException {
+        while (true) {
+            int bytesRead = super.read(buf, off, len);
+            if (bytesRead <= 0) {
+                return bytesRead;
+            }
+
+            // Compact non-null bytes toward the front of the buffer
+            int writePos = off;
+            for (int i = off; i < off + bytesRead; i++) {
+                if (buf[i] != 0) {
+                    buf[writePos++] = buf[i];
+                } else {
+                    nullByteDetected = true;
+                }
+            }
+
+            int filtered = writePos - off;
+            if (filtered > 0) {
+                return filtered;
+            }
+            // All bytes were null; loop to read the next chunk
+        }
+    }
+
+    /** Disable mark/reset since byte positions shift after filtering. */
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+}

--- a/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
+++ b/src/main/java/org/embulk/input/soql/SoqlFilePlugin.java
@@ -109,10 +109,17 @@ public class SoqlFilePlugin implements FileInputPlugin {
             for (Iterator<String> it = recordKeyList.iterator(); it.hasNext(); ) {
                 Path csv = tempFileSpace.createTempFile().toPath();
                 csvFilePaths.add(csv);
+                NullByteFilterInputStream filtered;
                 try (InputStream input =
                         bulkConnection.getQueryResultStream(
                                 jobInfo.getId(), batchInfo.getId(), it.next())) {
-                    Files.copy(input, csv, REPLACE_EXISTING);
+                    filtered = new NullByteFilterInputStream(input);
+                    Files.copy(filtered, csv, REPLACE_EXISTING);
+                }
+                if (filtered.hasDetectedNullBytes()) {
+                    logger.warn(
+                            "Null bytes (0x00) were detected and removed from the Bulk API response CSV. "
+                                    + "The source Salesforce data may contain invalid characters.");
                 }
             }
         } catch (AsyncApiException e) {

--- a/src/test/java/org/embulk/input/soql/TestNullByteFilterInputStream.java
+++ b/src/test/java/org/embulk/input/soql/TestNullByteFilterInputStream.java
@@ -1,0 +1,215 @@
+package org.embulk.input.soql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import org.junit.Test;
+
+public class TestNullByteFilterInputStream {
+
+    @Test
+    public void testReadSingleByte() throws IOException {
+        byte[] input = {0x41, 0x00, 0x42, 0x00, 0x43}; // A \0 B \0 C
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            assertEquals('A', stream.read());
+            assertEquals('B', stream.read());
+            assertEquals('C', stream.read());
+            assertEquals(-1, stream.read());
+        }
+    }
+
+    @Test
+    public void testReadSingleByteAllNulls() throws IOException {
+        byte[] input = {0x00, 0x00, 0x00};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            assertEquals(-1, stream.read());
+        }
+    }
+
+    @Test
+    public void testReadBuffer() throws IOException {
+        byte[] input = {0x41, 0x00, 0x42, 0x00, 0x43}; // A \0 B \0 C
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[10];
+            int read = stream.read(buf, 0, buf.length);
+            assertEquals(3, read);
+            assertEquals('A', buf[0]);
+            assertEquals('B', buf[1]);
+            assertEquals('C', buf[2]);
+        }
+    }
+
+    @Test
+    public void testReadBufferAllNulls() throws IOException {
+        byte[] input = {0x00, 0x00, 0x00};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[10];
+            int read = stream.read(buf, 0, buf.length);
+            assertEquals(-1, read);
+        }
+    }
+
+    @Test
+    public void testReadBufferNoNulls() throws IOException {
+        byte[] input = {0x41, 0x42, 0x43}; // A B C
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[10];
+            int read = stream.read(buf, 0, buf.length);
+            assertEquals(3, read);
+            assertEquals('A', buf[0]);
+            assertEquals('B', buf[1]);
+            assertEquals('C', buf[2]);
+        }
+    }
+
+    @Test
+    public void testReadBufferWithOffset() throws IOException {
+        byte[] input = {0x41, 0x00, 0x42};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[10];
+            buf[0] = 0x58; // X - should not be overwritten
+            int read = stream.read(buf, 1, 9);
+            assertEquals(2, read);
+            assertEquals('X', buf[0]); // untouched
+            assertEquals('A', buf[1]);
+            assertEquals('B', buf[2]);
+        }
+    }
+
+    @Test
+    public void testEmptyStream() throws IOException {
+        byte[] input = {};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            assertEquals(-1, stream.read());
+
+            byte[] buf = new byte[10];
+            assertEquals(-1, stream.read(buf, 0, buf.length));
+        }
+    }
+
+    @Test
+    public void testCsvWithNullBytes() throws IOException {
+        // Simulate Salesforce Bulk API CSV with null byte in a field value
+        String csv = "\"Id\",\"Name\",\"Field__c\"\n\"001\",\"test\",\"before\u0000after\"\n";
+        byte[] input = csv.getBytes("UTF-8");
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[1024];
+            int read = stream.read(buf, 0, buf.length);
+
+            String result = new String(buf, 0, read, "UTF-8");
+            String expected = "\"Id\",\"Name\",\"Field__c\"\n\"001\",\"test\",\"beforeafter\"\n";
+            assertEquals(expected, result);
+        }
+    }
+
+    @Test
+    public void testNormalCsvWithoutNullBytes() throws IOException {
+        // Typical Salesforce Bulk API CSV with no null bytes - should pass through unchanged
+        String csv =
+                "\"Id\",\"Name\",\"Description\"\n"
+                        + "\"001ABC\",\"Acme Corp\",\"Some description\"\n"
+                        + "\"002DEF\",\"Test Inc\",\"Another row\"\n";
+        byte[] input = csv.getBytes("UTF-8");
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[1024];
+            int read = stream.read(buf, 0, buf.length);
+            String result = new String(buf, 0, read, "UTF-8");
+            assertEquals(csv, result);
+        }
+    }
+
+    @Test
+    public void testNormalCsvWithMultibyteCharacters() throws IOException {
+        String csv = "\"Id\",\"Name\"\n\"001\",\"日本語テスト\"\n";
+        byte[] input = csv.getBytes("UTF-8");
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[1024];
+            int read = stream.read(buf, 0, buf.length);
+            String result = new String(buf, 0, read, "UTF-8");
+            assertEquals(csv, result);
+        }
+    }
+
+    @Test
+    public void testNormalCsvWithNewlinesInQuotedField() throws IOException {
+        // Quoted field containing newlines - common in Salesforce long text areas
+        String csv = "\"Id\",\"Notes\"\n\"001\",\"line1\nline2\nline3\"\n";
+        byte[] input = csv.getBytes("UTF-8");
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[1024];
+            int read = stream.read(buf, 0, buf.length);
+            String result = new String(buf, 0, read, "UTF-8");
+            assertEquals(csv, result);
+        }
+    }
+
+    @Test
+    public void testMarkNotSupported() throws IOException {
+        byte[] input = {0x41};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            assertFalse(stream.markSupported());
+        }
+    }
+
+    @Test
+    public void testNullBytesAtBoundaries() throws IOException {
+        // Null bytes at start and end
+        byte[] input = {0x00, 0x41, 0x42, 0x00};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[10];
+            int read = stream.read(buf, 0, buf.length);
+            assertEquals(2, read);
+            assertEquals('A', buf[0]);
+            assertEquals('B', buf[1]);
+        }
+    }
+
+    @Test
+    public void testHasDetectedNullBytesWhenPresent() throws IOException {
+        byte[] input = {0x41, 0x00, 0x42};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[10];
+            stream.read(buf, 0, buf.length);
+            assertTrue(stream.hasDetectedNullBytes());
+        }
+    }
+
+    @Test
+    public void testHasDetectedNullBytesWhenAbsent() throws IOException {
+        byte[] input = {0x41, 0x42, 0x43};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            byte[] buf = new byte[10];
+            stream.read(buf, 0, buf.length);
+            assertFalse(stream.hasDetectedNullBytes());
+        }
+    }
+
+    @Test
+    public void testHasDetectedNullBytesWithSingleByteRead() throws IOException {
+        byte[] input = {0x41, 0x00, 0x42};
+        try (NullByteFilterInputStream stream =
+                new NullByteFilterInputStream(new ByteArrayInputStream(input))) {
+            stream.read();
+            stream.read();
+            assertTrue(stream.hasDetectedNullBytes());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Salesforce Bulk API can return CSV data containing null bytes (0x00) in text fields (e.g. textarea). This causes Embulk's CSV parser to fail with parse errors and transfer failures.
- This PR adds `NullByteFilterInputStream` that wraps the Bulk API response stream and removes null bytes before passing the data to Embulk's CSV parser.
- A WARN log is emitted per result set file when null bytes are detected, so users are aware of data quality issues in the source.

## Background

- Null bytes (0x00) are not valid characters in RFC 4180 CSV. Their presence in Salesforce data is abnormal and likely caused by external integrations writing invalid data via API.
- Salesforce's textarea fields can store null bytes (confirmed via Apex `String.fromCharArray`), and the Bulk API returns them as-is in CSV responses.
- The null byte removal happens at the stream level (in-place filtering within the read buffer), so there is no additional memory overhead.

## Root Cause Analysis

Embulk's `CsvTokenizer` uses `'\0'` (null character) as an internal `END_OF_LINE` sentinel value. When actual null bytes appear in the CSV data, `isEndOfLine()` returns true, causing the tokenizer to misinterpret the data.

The specific error depends on whether there are subsequent records after the one containing the null byte:

### Case 1: No subsequent records → `Unexpected end of line`

When the null byte is in the last record, the tokenizer treats it as a multi-line quoted value and calls `nextLine()`. Since there is no next line, it throws:
```
Unexpected end of line during parsing a quoted value
```

### Case 2: Subsequent records exist → `Unexpected extra character`

When there are records after the one containing the null byte, the tokenizer:
1. Hits null byte in `QUOTED_VALUE` state → treats as end of line
2. Calls `nextLine()` to handle multi-line quoted value → reads the **next record's line** as continuation
3. Encounters `"` at the start of the next record → interprets as closing quote
4. Sees the next character (e.g. `0` from a Salesforce Id `"003..."`) → throws:
```
Unexpected extra character '0' after a value quoted by '"'
```

This happens even with `stop_on_invalid_record: true` because it is the **first** error — the null byte itself does not trigger an error, but causes the tokenizer to misparse subsequent data.

## Investigation

Tested various character patterns to determine which ones actually break CSV parsing:

| Pattern | Stored in Salesforce | Causes CSV parse error |
|---------|:---:|:---:|
| Null byte (0x00) | Yes | **Yes** — tokenizer misinterprets as END_OF_LINE |
| Other control chars (0x01-0x1F) | Yes | No |
| Double quotes in values | Yes | No — Bulk API escapes as `""` |
| Newlines (LF) in values | Yes | No — Bulk API wraps in quotes |
| CRLF in values | Yes | No — Bulk API wraps in quotes |
| Commas in values | Yes | No — Bulk API wraps in quotes |

Only null bytes cause parse errors. Other special characters are handled correctly by the Bulk API's CSV generation.

## Changes

- **`NullByteFilterInputStream`** (new): A `FilterInputStream` that filters out null bytes in-place during reads. Tracks whether any null bytes were detected via `hasDetectedNullBytes()`.
- **`SoqlFilePlugin`**: Wraps Bulk API response streams with `NullByteFilterInputStream` and logs a WARN when null bytes are found.
- **`TestNullByteFilterInputStream`** (new): 15 unit tests covering null byte filtering, normal data passthrough (including multibyte characters and newlines in quoted fields), edge cases, and detection flag behavior.

## Test plan

- [x] Unit tests pass (`./gradlew test`)
- [x] Verified with Salesforce sandbox: transfer succeeds with null byte data that previously caused parse errors
- [x] Verified WARN log is emitted when null bytes are detected
- [x] Verified normal data (without null bytes) passes through unchanged
- [x] Verified other special characters (control chars, quotes, newlines, commas) are not affected
- [x] Reproduced both `Unexpected end of line` and `Unexpected extra character '0'` errors with unfixed code, confirmed both are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)